### PR TITLE
Revert footer year from 1405 to 1404

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       این پروژه <strong>اپن‌سورس</strong> است و می‌توانید در توسعه‌ی آن مشارکت کنید:
       <a href="https://github.com/Mahdi-Hazrati/baskon.ir" target="_blank" rel="noopener">GitHub</a>
     </p>
-    <p>© 1405 بس کن ایرانی - تمامی حقوق محفوظ است.</p>
+    <p>© 1404 بس کن ایرانی - تمامی حقوق محفوظ است.</p>
   </footer>
 
   <!-- Scripts -->


### PR DESCRIPTION
This pull request corrects the footer year from 1405 to 1404 in the Persian calendar.

The year 1405 was mistakenly added earlier. Since we are still in 1404, this update ensures that the footer reflects the correct year.
